### PR TITLE
feat: webClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,8 @@ dependencies {
 	implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4.1'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/team/router/recycle/controller/RouteController.java
+++ b/src/main/java/team/router/recycle/controller/RouteController.java
@@ -2,7 +2,7 @@ package team.router.recycle.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import team.router.recycle.domain.route.RouteRequest.getDirectionRequest;
+import team.router.recycle.domain.route.RouteRequest.GetDirectionRequest;
 import team.router.recycle.domain.route.RouteService;
 
 @RestController
@@ -15,8 +15,8 @@ public class RouteController {
     }
 
     @PostMapping("/cycle")
-    public ResponseEntity<?> cycleV1(@RequestBody getDirectionRequest getDirectionRequest) {
-        return routeService.cycleV1(getDirectionRequest);
+    public ResponseEntity<?> getDirection(@RequestBody GetDirectionRequest getDirectionRequest) {
+        return routeService.getDirection(getDirectionRequest);
     }
 
     @PostMapping("/station")

--- a/src/main/java/team/router/recycle/controller/StationController.java
+++ b/src/main/java/team/router/recycle/controller/StationController.java
@@ -4,22 +4,24 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import team.router.recycle.Response;
 import team.router.recycle.domain.station.StationService;
-
-import java.io.IOException;
 
 @RestController
 @RequestMapping("/station")
 public class StationController {
 
     private final StationService stationService;
+    private final Response response;
 
-    public StationController(StationService stationService) {
+    public StationController(StationService stationService, Response response) {
         this.stationService = stationService;
+        this.response = response;
     }
 
     @PostMapping("/init")
-    public ResponseEntity<?> initStation() throws IOException {
-        return stationService.initStation();
+    public ResponseEntity<?> initStation() {
+        stationService.initStation();
+        return response.success();
     }
 }

--- a/src/main/java/team/router/recycle/domain/route/Distance.java
+++ b/src/main/java/team/router/recycle/domain/route/Distance.java
@@ -1,14 +1,4 @@
 package team.router.recycle.domain.route;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
-@Getter
-public class Distance {
-    private int meters;
-
-    public Distance(int meters) {
-        this.meters = meters;
-    }
+public record Distance(int meters) {
 }

--- a/src/main/java/team/router/recycle/domain/route/Duration.java
+++ b/src/main/java/team/router/recycle/domain/route/Duration.java
@@ -1,12 +1,4 @@
 package team.router.recycle.domain.route;
 
-import lombok.Getter;
-
-@Getter
-public class Duration {
-    private int seconds;
-
-    public Duration(int seconds) {
-        this.seconds = seconds;
-    }
+public record Duration(int seconds) {
 }

--- a/src/main/java/team/router/recycle/domain/route/GetDirectionResponseDeserializer.java
+++ b/src/main/java/team/router/recycle/domain/route/GetDirectionResponseDeserializer.java
@@ -1,0 +1,28 @@
+package team.router.recycle.domain.route;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetDirectionResponseDeserializer extends JsonDeserializer<RouteResponse.getDirectionResponse> {
+    @Override
+    public RouteResponse.getDirectionResponse deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        JsonNode node = parser.getCodec().readTree(parser);
+        RouteResponse.getDirectionResponse response = new RouteResponse.getDirectionResponse();
+        response.setRoutingProfile(RoutingProfile.valueOf(node.get("weight_name").asText()));
+        response.setDistance(new Distance(node.get("distance").asInt()));
+        response.setDuration(new Duration(node.get("duration").asInt()));
+        List<Location> locations = new ArrayList<>();
+        for (JsonNode coordinate : node.get("geometry").get("coordinates")) {
+            locations.add(new Location(coordinate.get(1).asDouble(),
+                    coordinate.get(0).asDouble()));
+        }
+        response.setLocations(locations);
+        return response;
+    }
+}

--- a/src/main/java/team/router/recycle/domain/route/Location.java
+++ b/src/main/java/team/router/recycle/domain/route/Location.java
@@ -1,16 +1,4 @@
 package team.router.recycle.domain.route;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
-@Getter
-public class Location {
-    private double latitude;
-    private double longitude;
-
-    public Location(double latitude, double longitude) {
-        this.latitude = latitude;
-        this.longitude = longitude;
-    }
+public record Location(double latitude, double longitude) {
 }

--- a/src/main/java/team/router/recycle/domain/route/RouteClient.java
+++ b/src/main/java/team/router/recycle/domain/route/RouteClient.java
@@ -1,0 +1,31 @@
+package team.router.recycle.domain.route;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class RouteClient {
+    private final WebClient client;
+    private final String MAPBOX_API_KEY;
+    String GEOJSON = "?geometries=geojson";
+    String ACCESS = "&access_token=";
+
+    public RouteClient(WebClient.Builder builder, @Value("${MAPBOX_API_KEY}") String MAPBOX_API_KEY) {
+        this.client = builder.baseUrl("https://api.mapbox.com/directions/v5/mapbox/")
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024)).build()
+                )
+                .build();
+        this.MAPBOX_API_KEY = MAPBOX_API_KEY;
+    }
+
+    public String getRouteInfo(String profile, String coordinate) {
+        return client.get()
+                .uri(profile + coordinate + GEOJSON + ACCESS + MAPBOX_API_KEY)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+}

--- a/src/main/java/team/router/recycle/domain/route/RouteRequest.java
+++ b/src/main/java/team/router/recycle/domain/route/RouteRequest.java
@@ -8,10 +8,8 @@ public class RouteRequest {
     @Getter
     @Setter
     @NoArgsConstructor
-    public static class getDirectionRequest {
-        private String startLatitude;
-        private String startLongitude;
-        private String endLatitude;
-        private String endLongitude;
+    public static class GetDirectionRequest {
+        private Location startLocation;
+        private Location endLocation;
     }
 }

--- a/src/main/java/team/router/recycle/domain/route/RouteResponse.java
+++ b/src/main/java/team/router/recycle/domain/route/RouteResponse.java
@@ -1,6 +1,7 @@
 package team.router.recycle.domain.route;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,6 +12,7 @@ public class RouteResponse {
 
     @Getter
     @Setter
+    @JsonDeserialize(using = GetDirectionResponseDeserializer.class)
     public static class getDirectionResponse {
         private RoutingProfile routingProfile;
         private Duration duration;
@@ -19,12 +21,12 @@ public class RouteResponse {
 
         @JsonGetter("duration")
         public int getDuration() {
-            return duration.getSeconds();
+            return duration.seconds();
         }
 
         @JsonGetter("distance")
         public int getDistance() {
-            return distance.getMeters();
+            return distance.meters();
         }
     }
 }

--- a/src/main/java/team/router/recycle/domain/station/Station.java
+++ b/src/main/java/team/router/recycle/domain/station/Station.java
@@ -1,5 +1,6 @@
 package team.router.recycle.domain.station;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,12 +18,24 @@ public class Station {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
+    @JsonProperty("RENT_NO")
     private String stationNumber;
+
+    @JsonProperty("RENT_NM")
     private String stationName;
+
+    @JsonProperty("RENT_ID_NM")
     private String stationNumberName;
+
+    @JsonProperty("STA_ADD1")
     private String stationAddress1;
+
+    @JsonProperty("STA_ADD2")
     private String stationAddress2;
+
+    @JsonProperty("STA_LAT")
     private Double stationLatitude;
+
+    @JsonProperty("STA_LONG")
     private Double stationLongitude;
 }

--- a/src/main/java/team/router/recycle/domain/station/StationClient.java
+++ b/src/main/java/team/router/recycle/domain/station/StationClient.java
@@ -1,0 +1,32 @@
+package team.router.recycle.domain.station;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+
+@Component
+public class StationClient {
+
+    private final WebClient client;
+    private final String SEOUL_API_KEY;
+
+
+    public StationClient(WebClient.Builder builder, @Value("${SEOUL_API_KEY}") String SEOUL_API_KEY) {
+        this.client = builder.baseUrl("http://openapi.seoul.go.kr:8088/")
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024)).build()
+                ).build();
+        this.SEOUL_API_KEY = SEOUL_API_KEY;
+    }
+
+    public String getStationInfo(String target) {
+        return client.get()
+                .uri(SEOUL_API_KEY + "/json/tbCycleStationInfo" + target)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+}
+

--- a/src/main/java/team/router/recycle/domain/station/StationService.java
+++ b/src/main/java/team/router/recycle/domain/station/StationService.java
@@ -1,59 +1,38 @@
 package team.router.recycle.domain.station;
 
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
+import org.springframework.stereotype.Service;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Service;
-import team.router.recycle.Response;
 
 @Service
 public class StationService {
 
-    @Value("${SEOUL_API_KEY}")
-    private String SEOUL_API_KEY;
-
-    private final Response response;
     private final StationRepository stationRepository;
     private final ExecutorService executorService;
+    private final StationClient client;
 
-    public StationService(Response response, StationRepository stationRepository) {
-        this.response = response;
+    public StationService(StationRepository stationRepository, StationClient client) {
         this.stationRepository = stationRepository;
         this.executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+        this.client = client;
     }
 
-    public ResponseEntity<?> initStation() {
-        String BASE_URL = "http://openapi.seoul.go.kr:8088";
-        String API_KEY = SEOUL_API_KEY;
-        String MASTER_PATH = "/json/tbCycleStationInfo";
+    public void initStation() {
         String[] TARGET_LIST = {"/1/1000", "/1001/2000", "/2001/3000", "/3001/4000"};
 
         List<CompletableFuture<Void>> futures = new ArrayList<>();
 
         for (String target : TARGET_LIST) {
-            URL MASTER_URL;
-            try {
-                MASTER_URL = new URL(BASE_URL + API_KEY + MASTER_PATH + target);
-            } catch (MalformedURLException e) {
-                return response.fail("Invalid URL", HttpStatus.BAD_REQUEST);
-            }
             futures.add(CompletableFuture.runAsync(() -> {
-                try (BufferedReader br = new BufferedReader(
-                        new InputStreamReader(MASTER_URL.openStream(), StandardCharsets.UTF_8))) {
-                    String result = br.readLine();
+                try {
+                    String result = client.getStationInfo(target);
+
                     ObjectMapper objectMapper = new ObjectMapper();
                     JsonNode jsonNode = objectMapper.readTree(result).get("stationInfo").get("row");
                     List<Station> stationList = new ArrayList<>();
@@ -62,7 +41,7 @@ public class StationService {
                                 .startsWith("0")) {
                             continue;
                         }
-                        Station newStation = Station.builder()
+                        stationList.add(Station.builder()
                                 .stationNumber(station.get("RENT_NO").asText())
                                 .stationName(station.get("RENT_NM").asText())
                                 .stationNumberName(station.get("RENT_ID_NM").asText())
@@ -70,8 +49,7 @@ public class StationService {
                                 .stationAddress2(station.get("STA_ADD2").asText())
                                 .stationLatitude(station.get("STA_LAT").asDouble())
                                 .stationLongitude(station.get("STA_LONG").asDouble())
-                                .build();
-                        stationList.add(newStation);
+                                .build());
                     }
                     stationRepository.saveAll(stationList);
                 } catch (Exception e) {
@@ -80,8 +58,8 @@ public class StationService {
             }, executorService));
         }
 
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-
-        return response.success();
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).thenRun(() -> {
+            System.out.println("Station init complete");
+        });
     }
 }


### PR DESCRIPTION
기존의 Service단에 너무나 많은 외부 api 로직들을 WebClient를 이용하여 기존 비동기 병렬 로직을 유지한채 StationClient로 책임을 분산시켰습니다.

`String[] TARGET_LIST = {"/1/1000", "/1001/2000", "/2001/3000", "/3001/4000"};` 까지도 client 단으로 넘길 수 있을 거 같습니다.

또한 Station 객체를 생성하는 과정에서 빌더를 이용하고 있지만, JsonNode와 객체를 서로 매핑해주는 다른 방법이 있을 것 같습니다.